### PR TITLE
Tests take project status value from Jira rather than hardcoding it as 10002

### DIFF
--- a/jira7/tests/tests.bal
+++ b/jira7/tests/tests.bal
@@ -8,6 +8,7 @@ ProjectSummary[] projectSummaryArray_test = [];
 ProjectComponent projectComponent_test = {};
 ProjectCategory projectCategory_test = {};
 Issue issue_test = {};
+ProjectStatus project_status = {};
 
 endpoint Client jiraConnectorEP {
     clientConfig: {
@@ -237,7 +238,7 @@ function test_getAllIssueTypeStatusesOfProject() {
 
     var output = jiraConnectorEP->getAllIssueTypeStatusesOfProject(project_test);
     match output {
-        ProjectStatus[] => {}
+        ProjectStatus[] p => project_status = p[0];
         JiraConnectorError e => test:assertFail(msg = e.message);
     }
 }
@@ -399,7 +400,7 @@ function test_deleteProjectCategory() {
 }
 
 @test:Config {
-    dependsOn: ["test_getProject"]
+    dependsOn: ["test_getProject", "test_getAllIssueTypeStatusesOfProject"]
 }
 function test_createIssue() {
     log:printInfo("ACTION : createIssue()");
@@ -407,7 +408,7 @@ function test_createIssue() {
     IssueRequest newIssue = {
         key: "TESTISSUE",
         summary: "This is a test issue created for Ballerina Jira Connector",
-        issueTypeId: "10002",
+        issueTypeId: project_status.id,
         projectId: project_test.id,
         assigneeName: config:getAsString("test_username")
     };


### PR DESCRIPTION
…

## Purpose
Tests fail if the jira instance is not fresh as the project status is hardcoded as 10002

## Goals
Goal is to make tests more durable. Take the project status value from jira.

## Approach


## User stories


## Release note


## Documentation


## Training


## Certification


## Marketing


## Automation tests


## Security checks


## Samples


## Related PRs


## Migrations (if applicable)


## Test environment

 
## Learning
