### PR TITLE
make the jira error visible when a test fails

### DIFF
--- a/jira7/tests/tests.bal
+++ b/jira7/tests/tests.bal
@@ -20,6 +20,11 @@ endpoint Client jiraConnectorEP {
     }
 };
 
+
+function formatJiraConnError(JiraConnectorError e) returns string {
+    return string `{{e.message}} - {{e.jiraServerErrorLog.errors.toString()}}`;
+}
+
 @test:BeforeSuite
 function connector_init() {
     //To avoid test failure of 'test_createProject()', if a project already exists with the same name.
@@ -35,7 +40,7 @@ function test_getAllProjectSummaries() {
         ProjectSummary[] projectSummaryArray => {
             projectSummaryArray_test = projectSummaryArray;
         }
-        JiraConnectorError e => test:assertFail(msg = e.message);
+        JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -48,7 +53,7 @@ function test_getAllDetailsFromProjectSummary() {
     var output = jiraConnectorEP->getAllDetailsFromProjectSummary(projectSummaryArray_test[0]);
     match output {
         Project => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -79,7 +84,7 @@ function test_createProject() {
         Project p => {
             project_test = p;
         }
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -97,7 +102,7 @@ function test_updateProject() {
     var output = jiraConnectorEP->updateProject("TSTPROJECT", projectUpdate);
     match output {
         boolean => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -126,7 +131,7 @@ function test_deleteProject() {
     var output = jiraConnectorEP->deleteProject("TSTPROJECT");
     match output {
         boolean => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -142,7 +147,7 @@ function test_getProject() {
         Project p => {
             project_test = p;
         }
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -155,7 +160,7 @@ function test_getLeadUserDetailsOfProject() {
     var output = jiraConnectorEP->getLeadUserDetailsOfProject(project_test);
     match output {
         User => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -168,7 +173,7 @@ function test_getRoleDetailsOfProject() {
     var output = jiraConnectorEP->getRoleDetailsOfProject(project_test, "10002");
     match output {
         ProjectRole => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -182,7 +187,7 @@ function test_addUserToRoleOfProject() {
         config:getAsString("test_username"));
     match output {
         boolean => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -196,7 +201,7 @@ function test_addGroupToRoleOfProject() {
         "jira-administrators");
     match output {
         boolean => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -210,7 +215,7 @@ function test_removeUserFromRoleOfProject() {
         config:getAsString("test_username"));
     match output {
         boolean => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -225,7 +230,7 @@ function test_removeGroupFromRoleOfProject() {
         "jira-administrators");
     match output {
         boolean => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -238,7 +243,7 @@ function test_getAllIssueTypeStatusesOfProject() {
     var output = jiraConnectorEP->getAllIssueTypeStatusesOfProject(project_test);
     match output {
         ProjectStatus[] => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -251,7 +256,7 @@ function test_changeTypeOfProject() {
     var output = jiraConnectorEP->changeTypeOfProject(project_test, "software");
     match output {
         boolean => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -276,7 +281,7 @@ function test_createProjectComponent() {
         ProjectComponent component => {
             projectComponent_test = component;
         }
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -294,7 +299,7 @@ function test_getProjectComponent() {
         ProjectComponent component => {
             projectComponent_test = component;
         }
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -307,7 +312,7 @@ function test_getAssigneeUserDetailsOfProjectComponent() {
     var output = jiraConnectorEP->getAssigneeUserDetailsOfProjectComponent(projectComponent_test);
     match output {
         User => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -320,7 +325,7 @@ function test_getLeadUserDetailsOfProjectComponent() {
     var output = jiraConnectorEP->getLeadUserDetailsOfProjectComponent(projectComponent_test);
     match output {
         User => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -337,7 +342,7 @@ function test_deleteProjectComponent() {
     var output = jiraConnectorEP->deleteProjectComponent(projectComponent_test.id);
     match output {
         boolean => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -348,7 +353,7 @@ function test_getAllProjectCategories() {
     var output = jiraConnectorEP->getAllProjectCategories();
     match output {
         ProjectCategory[] => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -366,7 +371,6 @@ function test_createProjectCategory() {
         }
         JiraConnectorError e => test:assertFail(msg = string `{{e.message}} - { Please retry again after removing
          the project category:'{{newCategory.name}}' from from your jira instance}`);
-
     }
 }
 
@@ -381,7 +385,7 @@ function test_getProjectCategory() {
         ProjectCategory category => {
             projectCategory_test = category;
         }
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -394,7 +398,7 @@ function test_deleteProjectCategory() {
     var output = jiraConnectorEP->deleteProjectCategory(projectCategory_test.id);
     match output {
         boolean => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -417,7 +421,7 @@ function test_createIssue() {
         Issue issue => {
             issue_test = issue;
         }
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -432,7 +436,7 @@ function test_getIssue() {
         Issue issue => {
             issue_test = issue;
         }
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -445,7 +449,7 @@ function test_deleteIssue() {
     var output = jiraConnectorEP->deleteIssue(issue_test.key);
     match output {
         boolean => {}
-        JiraConnectorError e => test:assertFail(msg = e.message);
+	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 


### PR DESCRIPTION
## Purpose
When a test fails it's hard to diagnose as the Jira error message is not displayed.

## Goals
Display the Jira error message

## Approach

## User stories


## Release note


## Documentation


## Training


## Certification


## Marketing


## Automation tests


## Security checks


## Samples


## Related PRs


## Migrations (if applicable)


## Test environment

 
## Learning
