### PR TITLE
Add a comment to an issue and retrieve the comments

### DIFF
--- a/jira7/jira_connector.bal
+++ b/jira7/jira_connector.bal
@@ -101,6 +101,8 @@ public type JiraConnector object {
     public function deleteIssue(string issueIdOrKey)
                         returns boolean|JiraConnectorError;
 
+    public function addCommentToIssue(string issueIdOrKey, IssueComment comment)
+                        returns boolean|JiraConnectorError;
 };
 
 documentation{Returns an array of all projects summaries which are visible for the currently logged in user who has
@@ -871,3 +873,30 @@ function JiraConnector::deleteIssue(string issueIdOrKey) returns boolean|JiraCon
         json jsonResponse => return true;
     }
 }
+
+documentation{Adds a comment to a Jira Issue.
+    P{{issueIdOrKey}} id or key of the issue
+    P{{comment}} the details of the comment to be added
+    R{{^"boolean"}} returns true if the process is successful
+    R{{JiraConnectorError}} 'JiraConnectorError' record
+}
+function JiraConnector::addCommentToIssue(string issueIdOrKey, IssueComment comment)
+            returns boolean|JiraConnectorError {
+
+    endpoint http:Client jiraHttpClientEP = self.jiraHttpClient;
+    http:Request commentRequest = new;
+
+    json jsonPayload = {};
+    jsonPayload.body = comment.body;
+    commentRequest.setJsonPayload(jsonPayload);
+
+    var httpResponseOut = jiraHttpClientEP->post("/issue/" + issueIdOrKey +"/comment", commentRequest);
+    //Evaluate http response for connection and server errors
+    var jsonResponseOut = getValidatedResponse(httpResponseOut);
+
+    match jsonResponseOut {
+        JiraConnectorError e => return e;
+        json jsonResponse => return true;
+    }
+}
+

--- a/jira7/jira_data_mappings.bal
+++ b/jira7/jira_data_mappings.bal
@@ -181,8 +181,8 @@ function jsonToIssue(json source) returns Issue {
             i +=1;
         }
     }
-
-return target;
+    target.comments = jsonToIssueComments(source.fields.comment.comments);
+    return target;
 }
 
 function jsonToIssueSummary(json source) returns IssueSummary {
@@ -234,3 +234,27 @@ function issueRequestToJson(IssueRequest source) returns json {
 
     return target;
 }
+
+function jsonToIssueComments(json jcomments) returns IssueComment[] {
+
+    IssueComment[] comments = [];
+    int l = lengthof jcomments;
+    foreach (jcomment in jcomments) {
+        comments[lengthof comments] = jsonToIssueComment(jcomment);
+    }
+    return comments;
+}
+
+function jsonToIssueComment(json jcomment) returns IssueComment {
+
+    IssueComment comment = {};
+
+    comment.id = jcomment.id.toString();
+    comment.authorName = jcomment.author.name.toString();
+    comment.authorKey = jcomment.author.key.toString();
+    comment.body = jcomment.body.toString();
+    comment.updatedDate = jcomment.updated.toString();
+
+    return comment;
+}
+

--- a/jira7/jira_types.bal
+++ b/jira7/jira_types.bal
@@ -325,6 +325,7 @@ public type Issue record {
     IssueType issueType;
     IssueSummary parent;
     ProjectSummary project;
+    IssueComment[] comments = [];
     json[] customFields = [];
 };
 
@@ -376,3 +377,19 @@ public type JiraConnectorError record {
     string ^"type";
     json jiraServerErrorLog;
 };
+
+documentation{Represents record of jira issue comment.
+    F{{id}} issue id
+    F{{authorName}} Authors name of comment
+    F{{authorKey}} Authors key
+    F{{body}} Body of comment
+    F{{updatedDate}} Date of creation of comment
+}
+public type IssueComment record {
+    string id;
+    string authorName;
+    string authorKey;
+    string body;
+    string updatedDate;
+};
+

--- a/jira7/tests/tests.bal
+++ b/jira7/tests/tests.bal
@@ -8,6 +8,7 @@ ProjectSummary[] projectSummaryArray_test = [];
 ProjectComponent projectComponent_test = {};
 ProjectCategory projectCategory_test = {};
 Issue issue_test = {};
+string testComment = "This is a test comment created for Ballerina Jira Connector";
 
 endpoint Client jiraConnectorEP {
     clientConfig: {
@@ -424,6 +425,23 @@ function test_createIssue() {
 @test:Config {
     dependsOn: ["test_createIssue"]
 }
+function test_addCommentToIssue() {
+    log:printInfo("ACTION : addCommentToIssue()");
+
+    IssueComment newComment = {
+        body: testComment
+    };
+
+    var output = jiraConnectorEP->addCommentToIssue(issue_test.key, newComment);
+    match output {
+        boolean => {}
+        JiraConnectorError e => test:assertFail(msg = e.message);
+    }
+}
+
+@test:Config {
+    dependsOn: ["test_createIssue", "test_addCommentToIssue"]
+}
 function test_getIssue() {
     log:printInfo("ACTION : getIssue()");
 
@@ -437,7 +455,7 @@ function test_getIssue() {
 }
 
 @test:Config {
-    dependsOn: ["test_getIssue"]
+    dependsOn: ["test_getIssue", "test_addCommentToIssue"]
 }
 function test_deleteIssue() {
     log:printInfo("ACTION : deleteIssue()");


### PR DESCRIPTION
## Purpose
To enable adding of comments to Jira issues and to be able to retrieve them

## Goals

## Approach
Added new methof addCommentToIssue to JiraConnector. Added comments to the Issue type.

## User stories


## Release note


## Documentation


## Training


## Certification


## Marketing


## Automation tests


## Security checks


## Samples


## Related PRs


## Migrations (if applicable)


## Test environment

 
## Learning