### PR TITLE
Enable additional fields to be entered when issue is created

### DIFF
--- a/jira7/jira_connector.bal
+++ b/jira7/jira_connector.bal
@@ -814,7 +814,10 @@ function JiraConnector::getIssue(string issueIdOrKey) returns Issue|JiraConnecto
 
     endpoint http:Client jiraHttpClientEP = self.jiraHttpClient;
 
-    var httpResponseOut = jiraHttpClientEP->get("/issue/" + issueIdOrKey);
+    string getParams = "/issue/" + issueIdOrKey;
+    log:printDebug("GET : " + getParams);
+
+    var httpResponseOut = jiraHttpClientEP->get(getParams);
     //Evaluate http response for connection and server errors
     var jsonResponseOut = getValidatedResponse(httpResponseOut);
 
@@ -835,7 +838,7 @@ function JiraConnector::createIssue(IssueRequest newIssue) returns Issue|JiraCon
     http:Request outRequest = new;
 
     json jsonPayload = issueRequestToJson(newIssue);
-    log:printDebug("CreateIssue payload: "+jsonPayload.toString());
+    log:printDebug("CreateIssue payload: " + jsonPayload.toString());
     outRequest.setJsonPayload(jsonPayload);
 
     var httpResponseOut = jiraHttpClientEP->post("/issue", outRequest);

--- a/jira7/jira_connector.bal
+++ b/jira7/jira_connector.bal
@@ -835,6 +835,7 @@ function JiraConnector::createIssue(IssueRequest newIssue) returns Issue|JiraCon
     http:Request outRequest = new;
 
     json jsonPayload = issueRequestToJson(newIssue);
+    log:printDebug("CreateIssue payload: "+jsonPayload.toString());
     outRequest.setJsonPayload(jsonPayload);
 
     var httpResponseOut = jiraHttpClientEP->post("/issue", outRequest);

--- a/jira7/jira_data_mappings.bal
+++ b/jira7/jira_data_mappings.bal
@@ -225,13 +225,24 @@ function jsonToIssueType(json source) returns IssueType {
 function issueRequestToJson(IssueRequest source) returns json {
 
     json target = {fields:{}};
-
-    target.key = source.key != EMPTY_STRING ? source.key : null;
     target.fields.summary = source.summary != EMPTY_STRING ? source.summary : null;
     target.fields.issuetype = source.issueTypeId != EMPTY_STRING ? {id:source.issueTypeId} : null;
     target.fields.project = source.projectId != EMPTY_STRING ? {id:source.projectId} : null;
     target.fields.assignee = source.assigneeName != EMPTY_STRING ? {name:source.assigneeName} : null;
-
+    
+    map source_map = <map>source;
+    source_map["summary"] = null;
+    source_map["issueTypeId"] = null;
+    source_map["projectId"] = null;
+    source_map["assigneeName"] = null;
+    
+    foreach f in source_map.keys() {
+        match <json>source_map[f] {
+            () => source_map[f] = null; //do nothing
+            json j => target.fields[f] = j;
+            error e => target.fields[f] = <string>source_map[f];
+        }
+    }
     return target;
 }
 

--- a/jira7/jira_types.bal
+++ b/jira7/jira_types.bal
@@ -330,22 +330,16 @@ public type Issue record {
 };
 
 documentation{Represents record of jira issue creation template.
-    F{{key}} issue key
     F{{summary}} summary of the issue
     F{{issueTypeId}} Id of the issue type for the new issue
     F{{projectId}} Id of the project related to the new issue
-    F{{parentIssueKey}} issue key of parent of the new issue
     F{{assigneeName}} jira username of the issue assignee
-    F{{dueDate}} due date of the issue
 }
 public type IssueRequest record {
-    string key;
     string summary;
     string issueTypeId;
     string projectId;
-    string parentIssueKey;
     string assigneeName;
-    string dueDate;
 };
 
 documentation{Represents a jira issue.

--- a/jira7/tests/tests.bal
+++ b/jira7/tests/tests.bal
@@ -429,23 +429,23 @@ function test_createIssue() {
     dependsOn: ["test_getProject", "test_getAllIssueTypeStatusesOfProject"]
 }
 function test_createIssueWithExtraFields() {
-    string msg = "";
+    // Create issue including additional fields description and reporter 
     log:printInfo("ACTION : createIssueWithExtraFields()");
 
     IssueRequest newIssue = {
-        summary: "This is a test issue created for Ballerina Jira Connector with some extra data",
-        issueTypeId: "10004",
+        summary: "This is a test issue created for Ballerina Jira Connector with description and reporter",
+        issueTypeId: project_status.id,
         projectId: project_test.id,
         assigneeName: config:getAsString("test_username"),
         description: "test description"
     };
+    // Specify the reporter field in json format
     newIssue.reporter = <json>{name: config:getAsString("test_username")};
     
-    // This should fail to create issue as testField1 and testField2 do not exist on the Jira Project create form
     var output = jiraConnectorEP->createIssue(newIssue);
     match output {
-        JiraConnectorError e => msg = e.message;
-        Issue issue => test:assertFail(msg = "error: create issue with extra fields test should result in an error");
+        Issue issue => issue_test = issue;
+        JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
     }
 }
 
@@ -467,7 +467,7 @@ function test_addCommentToIssue() {
 }
 
 @test:Config {
-    dependsOn: ["test_createIssue", "test_addCommentToIssue"]
+    dependsOn: ["test_createIssue", "test_addCommentToIssue", "test_createIssueWithExtraFields"]
 }
 function test_getIssue() {
     log:printInfo("ACTION : getIssue()");
@@ -482,7 +482,7 @@ function test_getIssue() {
 }
 
 @test:Config {
-    dependsOn: ["test_getIssue", "test_addCommentToIssue"]
+    dependsOn: ["test_getIssue", "test_addCommentToIssue", "test_createIssueWithExtraFields"]
 }
 function test_deleteIssue() {
     log:printInfo("ACTION : deleteIssue()");

--- a/jira7/tests/tests.bal
+++ b/jira7/tests/tests.bal
@@ -412,7 +412,6 @@ function test_createIssue() {
     log:printInfo("ACTION : createIssue()");
 
     IssueRequest newIssue = {
-        key: "TESTISSUE",
         summary: "This is a test issue created for Ballerina Jira Connector",
         issueTypeId: project_status.id,
         projectId: project_test.id,
@@ -421,10 +420,32 @@ function test_createIssue() {
 
     var output = jiraConnectorEP->createIssue(newIssue);
     match output {
-        Issue issue => {
-            issue_test = issue;
-        }
+        Issue issue => issue_test = issue;
 	JiraConnectorError e => test:assertFail(msg = formatJiraConnError(e));
+    }
+}
+
+@test:Config {
+    dependsOn: ["test_getProject", "test_getAllIssueTypeStatusesOfProject"]
+}
+function test_createIssueWithExtraFields() {
+    string msg = "";
+    log:printInfo("ACTION : createIssueWithExtraFields()");
+
+    IssueRequest newIssue = {
+        summary: "This is a test issue created for Ballerina Jira Connector with some extra data",
+        issueTypeId: "10004",
+        projectId: project_test.id,
+        assigneeName: config:getAsString("test_username"),
+        description: "test description"
+    };
+    newIssue.reporter = <json>{name: config:getAsString("test_username")};
+    
+    // This should fail to create issue as testField1 and testField2 do not exist on the Jira Project create form
+    var output = jiraConnectorEP->createIssue(newIssue);
+    match output {
+        JiraConnectorError e => msg = e.message;
+        Issue issue => test:assertFail(msg = "error: create issue with extra fields test should result in an error");
     }
 }
 


### PR DESCRIPTION
## Purpose
Currently you populate the IssueRequest record and its values are converted to json and sent as POST payload to JIRA. Restriction here is that you can only add the fields currently in the IssueRecord. So if your Jira project has additional mandatory fields this package will NOT be able to create an issue.

## Goals
Remove the restriction as described above so we can create issue in JIRA with additional fields. 

## Approach
Allow user to add fields to the IssueRequest record which get converted to JSON and POSTed to Jira.

## User stories


## Release note


## Documentation


## Training


## Certification


## Marketing


## Automation tests


## Security checks


## Samples


## Related PRs


## Migrations (if applicable)


## Test environment

 
## Learning
